### PR TITLE
Fix Building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,9 +52,8 @@ file(GLOB_RECURSE SOURCES CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/src/*.cpp")
 list(FILTER SOURCES EXCLUDE REGEX "${CMAKE_BINARY_DIR}/.*")  # Exclude build directory
 
 # Add Executable
-add_executable(MyProject ${SOURCES})
-#add_executable(MyProject src/main.cpp include/FileDialogs/dialogs.cpp)
-#add_executable(MyProject src/main.cpp include/FileDialogs/dialogs.cpp include/Process/process.cpp)  # Explicitly list files or use proper globs
+#add_executable(MyProject ${SOURCES})
+add_executable(MyProject "src/main.cpp")
 
 # Copy data folder to build directory
 #add_custom_command(


### PR DESCRIPTION
Edit CMakeLists.txt `add_executable()` to fix building.

Without these changes applied you get the following cmake error:

```
ubuntu@ubuntu:~/Magma-Engine$ cmake .
-- Found Vulkan: /usr/lib/x86_64-linux-gnu/libvulkan.so (found version "1.4.321") found components: glslc glslangValidator 
-- Configured MyProject with the following libraries:
--   - Vulkan
--   - SDL3
-- Configuring done (0.1s)
CMake Error at CMakeLists.txt:55 (add_executable):
  No SOURCES given to target: MyProject


CMake Generate step failed.  Build files cannot be regenerated correctly.
```